### PR TITLE
Looks like the Debug transport_test-SHM-jemalloc failures seen on slo…

### DIFF
--- a/src/ipc/session/detail/session_base.hpp
+++ b/src/ipc/session/detail/session_base.hpp
@@ -248,7 +248,7 @@ protected:
    * could still claim to be non-blocking.  It's a matter of perspective really.  This value just seems to
    * cause less confusion.  We might reconsider the whole thing however.
    */
-  static constexpr util::Fine_duration S_OPEN_CHANNEL_TIMEOUT = boost::chrono::seconds(5);
+  static constexpr util::Fine_duration S_OPEN_CHANNEL_TIMEOUT = boost::chrono::seconds(60);
 
   /**
    * The max sendable MQ message size as decided by Server_session_impl::make_channel_mqs() (and imposed on both sides,


### PR DESCRIPTION
…wer (GitHub) machines are the result of the machine getting processor-pegged while handling the absurd amount of data being loaded or freed by the test, possibly concurrently; an internal timeout gets triggered.  But this timeout is arbitrary anyway.  I will consider whether there is anything to do here to improve SHM-jemalloc responsiveness when allocating/deallocating data, but in the meantime increasing this timeout is OK too; it is at least not worse.