### PR TITLE
Fix theoretical race. (also in ipc_shm_arena_lend) / Suppress locally-noticed false-positive TSAN warning (semaphore open).

### DIFF
--- a/src/ipc/session/detail/server_session_impl.hpp
+++ b/src/ipc/session/detail/server_session_impl.hpp
@@ -416,10 +416,7 @@ protected:
    */
   const Master_structured_channel& master_channel_const() const;
 
-  /**
-   * Analogous to Client_session_impl::dtor_async_worker_stop().  See that doc header.
-   * @return See above.
-   */
+  /// Analogous to Client_session_impl::dtor_async_worker_stop().  See that doc header.
   void dtor_async_worker_stop();
 
 private:

--- a/src/sanitize/tsan/suppressions_clang.cfg
+++ b/src/sanitize/tsan/suppressions_clang.cfg
@@ -1,0 +1,18 @@
+# Current version assumption: clang-15/16/17.
+
+# Had some issues matching ^ and $ in this one; leaving them out; these are very unlikely to match something
+# unintentional.
+
+# Seen locally (by ygoldfel; clang-17) but not in automated pipeline, this nevertheless looks like it could
+# pop up there, or anywhere, depending on timing. The good news is it's a straightforward false positive.
+# It manifests as
+#   SUMMARY: ThreadSanitizer: data race (.../test/suite/unit_test/libipc_unit_test.exec+0xd2264) ... in strcmp
+# but more saliently is a "race" between two threads concurrently each opening a bipc::named_mutex, in open-or-create
+# mode of operation.  (In this case it is "even" named the same thing for both... which is the whole point of it being
+# a cross-process *named* mutex.)  In unit_test, `Client_session`s are opened in parallel, so each one's
+# internal Client_session_impl legitimately does the named_mutex opening.  Inside that Boost (bipc) code
+# it calls into glibc to open a semaphore; the strcmp() is within glibc.  This is a completely vanilla opening of
+# semaphores by name; so either glibc has thread-unsafe code there (unlikely), or it's a false positive by TSAN
+# while checking glibc code (perhaps glibc itself would need to be instrumented to eliminate it?), but either way
+# for our context it's a false positive.
+race:boost::interprocess::named_mutex::named_mutex

--- a/test/basic/CMakeLists.txt
+++ b/test/basic/CMakeLists.txt
@@ -15,5 +15,4 @@
 # See the License for the specific language governing
 # permissions and limitations under the License.
 
-#XXX
-#add_subdirectory(link_test)
+add_subdirectory(link_test)

--- a/test/basic/CMakeLists.txt
+++ b/test/basic/CMakeLists.txt
@@ -15,4 +15,5 @@
 # See the License for the specific language governing
 # permissions and limitations under the License.
 
-add_subdirectory(link_test)
+#XXX
+#add_subdirectory(link_test)


### PR DESCRIPTION
While researching actual observed race in test code, it made me look into a reminiscent thing in my actual non-test code: There is ab obscure race possibility, when using SHM-jemalloc-enabled ipc::session: If one issues Client_session::async_connect() or Server_session::async_accept() and destroys the {Client|Server}_session (invokes dtor) immediately, before the connect/accept async-finishes, then there is a race. While unlikely -- we could even demand by contract to not do that -- I would rather not have any landmines sitting around or overly restrictive API docs. Fixing.