### PR TITLE
Boost v1.84 to 1.87 in Flow => slight breaking API changes in flow::error => fix/improve their use in this module.

### DIFF
--- a/src/ipc/session/detail/client_session_impl.hpp
+++ b/src/ipc/session/detail/client_session_impl.hpp
@@ -1095,7 +1095,7 @@ bool CLASS_CLI_SESSION_IMPL::sync_connect_impl(Error_code* err_code,
   using flow::async::Task_asio_err;
   using boost::promise;
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Client_session_impl::sync_connect_impl, _1, async_connect_impl_func);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, sync_connect_impl, _1, async_connect_impl_func);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   // We are in thread U.
@@ -2114,8 +2114,7 @@ bool CLASS_CLI_SESSION_IMPL::open_channel(Channel_obj* target_channel, const Mdt
 
   // We are in thread U.
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Client_session_impl::open_channel,
-                                     target_channel, flow::util::bind_ns::cref(mdt), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, open_channel, target_channel, mdt, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   if (!mdt)

--- a/src/ipc/session/detail/server_session_impl.hpp
+++ b/src/ipc/session/detail/server_session_impl.hpp
@@ -1081,8 +1081,7 @@ bool CLASS_SRV_SESSION_IMPL::open_channel(Channel_obj* target_channel, const Mdt
 
   // We are in thread U.
 
-  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, Server_session_impl::open_channel,
-                                     target_channel, flow::util::bind_ns::cref(mdt), _1);
+  FLOW_ERROR_EXEC_AND_THROW_ON_ERROR(bool, open_channel, target_channel, mdt, _1);
   // ^-- Call ourselves and return if err_code is null.  If got to present line, err_code is not null.
 
   if (!mdt)


### PR DESCRIPTION
This is downstream of flow PR https://github.com/Flow-IPC/flow/pull/100. Quoting the only part of that relevant to these changes:

- APIs are unchanged except:
  - a mostly backward-compatible improvement in FLOW_ERROR_EXEC_AND_THROW_ON_ERROR();
    - (but remove any bind_ns::cref() wrappers for args - they're not necessary and won't build)

Basically, in English: FLOW_ERROR_EXEC_AND_THROW_ON_ERROR() invocations have been simplified due to its new impl and improved API.