### PR TITLE
For Channels opened via `ipc::session`, ensure the socket-stream-specific method `remote_peer_process_credentials()` returns values relevant to the opposing process despite the details of how such channels are internally established (namely via `socketpair()`). / Add `Native_socket_stream::remote_peer_process_credentials()` mutator that allows one to correct this value when creating socket-streams more manually (such as is done internally by `ipc::session`).

### DIFF
--- a/src/ipc/session/detail/server_session_impl.hpp
+++ b/src/ipc/session/detail/server_session_impl.hpp
@@ -1416,6 +1416,16 @@ bool CLASS_SRV_SESSION_IMPL::create_channel_and_resources(Shared_name* mq_name_c
                    "connect_pair() generated native handles [" << local_hndl << "], [" << remote_hndl_or_null << "], "
                    "the latter to be transmitted to remote peer (client).");
     local_sock_stm_or_null = Native_socket_stream(get_logger(), nickname, std::move(local_hndl));
+
+    // Please see Native_socket_stream::remote_peer_process_credentials() doc header for explanation of this.
+    {
+      Error_code err_code;
+      local_sock_stm_or_null.remote_peer_process_credentials(m_master_channel->owned_channel()
+                                                               .remote_peer_process_credentials(&err_code));
+      assert((!err_code) && "By contract that should only fail if the socket got hosed via transmission; but "
+                            "it is a local socket we just established; so there is no way.");
+    }
+
     return true;
   }; // make_sock_stm_func =
 


### PR DESCRIPTION
Part of fix for: https://github.com/Flow-IPC/ipc/issues/148

Code review: reviewed elsewhere by @wkorbe.